### PR TITLE
Fix Chopper webshell detection & pretty print json output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module webshell-analyzer
+
+go 1.19

--- a/main.go
+++ b/main.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	cm "./common"
-	ft "./timestamps"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -13,6 +11,8 @@ import (
 	"regexp"
 	"sync"
 	"time"
+	cm "webshell-analyzer/common"
+	ft "webshell-analyzer/timestamps"
 )
 
 func Scan_worker(wg *sync.WaitGroup, rawContents bool) {

--- a/main.go
+++ b/main.go
@@ -69,7 +69,7 @@ func Scan_worker(wg *sync.WaitGroup, rawContents bool) {
 		}
 
 		// PROD
-		data, err := json.Marshal(Jdata)
+		data, err := json.MarshalIndent(Jdata, "", "  ")
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -333,7 +333,7 @@ func init() {
 		{
 			Name:        "ASP_Execution",
 			Description: "ASP functions associated with code execution",
-			Regex:       *regexp.MustCompile(`(?i)(?:e["+/*-]+v["+/*-]+a["+/*-]+l["+/*-]+\(|system\.diagnostics\.processstartinfo\(\w+\.substring\(|startinfo\.filename=\"?'?cmd\.exe"?'?|\seval\(request\.item\["?'?\w+"?'?\](?:,"?'?unsafe"?'?)?|execute(?:\(|\s+request\(\"\w+\"\))|RunCMD\(|\seval\(|COM\('?"?WScript\.(?:shell|network)"?'?|response\.write\()`),
+			Regex:       *regexp.MustCompile(`(?i)(?:e["+/*-]+v["+/*-]+a["+/*-]+l["+/*-]+\(|system\.diagnostics\.processstartinfo\(\w+\.substring\(|startinfo\.filename=\"?'?cmd\.exe"?'?|\seval\(request\.item\["?'?\w+"?'?\](?:,"?'?unsafe"?'?)?|execute(?:\(|\s+request\(\"\w+\"\))|RunCMD\(|eval\(|COM\('?"?WScript\.(?:shell|network)"?'?|response\.write\()`),
 		},
 		{
 			Name:        "Database_Command_Execution",
@@ -455,7 +455,7 @@ func main() {
 	metrics.SystemInfo.RealName = theUser.Name
 	metrics.SystemInfo.UserHomeDir = theUser.HomeDir
 
-	data, err := json.Marshal(metrics)
+	data, err := json.MarshalIndent(metrics, "", "  ")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/timestamps/timestamps_linux.go
+++ b/timestamps/timestamps_linux.go
@@ -1,10 +1,10 @@
 package timestamps
 
 import (
-	cm "../common"
 	"os"
 	"syscall"
 	"time"
+	cm "webshell-analyzer/common"
 )
 
 func StatTimes(filePath string) (wts cm.FileTimes, err error) {


### PR DESCRIPTION
I used to use https://github.com/tstillz/webshell-scan in DFIR.  While using this new version, I am a bit surprised that this does not detect Chopper web shell like the old version. 
So I fixed the regex and also pretty print json CLI output for easy reading. Hope it can help others with similar problems. 
By the way, personally I think this is one of the best web shell detection open source projects. Thanks @tstillz 